### PR TITLE
Hide `util` package from Javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -321,6 +321,9 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <excludePackageNames>net.jpountz.util</excludePackageNames>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.gradlex</groupId>

--- a/src/java/net/jpountz/util/ByteBufferUtils.java
+++ b/src/java/net/jpountz/util/ByteBufferUtils.java
@@ -20,6 +20,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
 
+/** <b>FOR INTERNAL USE ONLY</b> */
 public enum ByteBufferUtils {
   ;
 

--- a/src/java/net/jpountz/util/Native.java
+++ b/src/java/net/jpountz/util/Native.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.FilenameFilter;
 
-/** FOR INTERNAL USE ONLY */
+/** <b>FOR INTERNAL USE ONLY</b> */
 public enum Native {
   ;
 

--- a/src/java/net/jpountz/util/SafeUtils.java
+++ b/src/java/net/jpountz/util/SafeUtils.java
@@ -18,6 +18,7 @@ package net.jpountz.util;
 
 import java.nio.ByteOrder;
 
+/** <b>FOR INTERNAL USE ONLY</b> */
 public enum SafeUtils {
   ;
 

--- a/src/java/net/jpountz/util/Utils.java
+++ b/src/java/net/jpountz/util/Utils.java
@@ -18,6 +18,7 @@ package net.jpountz.util;
 
 import java.nio.ByteOrder;
 
+/** <b>FOR INTERNAL USE ONLY</b> */
 public enum Utils {
   ;
 

--- a/src/java/net/jpountz/util/package.html
+++ b/src/java/net/jpountz/util/package.html
@@ -19,6 +19,6 @@
    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 </head>
 <body>
-<p>Utility classes.</p>
+<p>Utility classes, <b>FOR INTERNAL USE ONLY</b></p>
 </body>
 </html>


### PR DESCRIPTION
This matches the original Ant build:
https://github.com/lz4/lz4-java/blob/be9ce5759ec6cce99544c7112e434be11aedb1a8/build.xml#L336