### PR TITLE
Migrate to maven-git-versioning-extension

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,7 +1,7 @@
   <extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
     <extension>
-      <groupId>fr.brouillard.oss</groupId>
-      <artifactId>jgitver-maven-plugin</artifactId>
-      <version>1.9.0</version>
+      <groupId>me.qoomon</groupId>
+      <artifactId>maven-git-versioning-extension</artifactId>
+      <version>9.11.0</version>
     </extension>
   </extensions>

--- a/.mvn/jgitver.config.xml
+++ b/.mvn/jgitver.config.xml
@@ -1,7 +1,0 @@
-<configuration xmlns="http://jgitver.github.io/maven/configuration/1.1.0"
-               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-               xsi:schemaLocation="http://jgitver.github.io/maven/configuration/1.1.0 https://jgitver.github.io/maven/configuration/jgitver-configuration-v1_1_0.xsd">
-    <!-- GitHub creates lightweight tags for releases, which the MAVEN strategy does not recognize. -->
-    <strategy>CONFIGURABLE</strategy>
-    <nonQualifierBranches>main,1.8.1</nonQualifierBranches>
-</configuration>

--- a/.mvn/maven-git-versioning-extension.xml
+++ b/.mvn/maven-git-versioning-extension.xml
@@ -1,0 +1,21 @@
+<configuration xmlns="https://github.com/qoomon/maven-git-versioning-extension"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="https://github.com/qoomon/maven-git-versioning-extension https://qoomon.github.io/maven-git-versioning-extension/configuration-9.4.0.xsd">
+  <projectVersionPattern>\d+\.\d+\.\d+</projectVersionPattern>
+  <describeTagPattern>v(\d+\.\d+\.\d+)</describeTagPattern>
+
+  <refs>
+    <ref type="branch">
+      <pattern>.+</pattern>
+      <version>${describe.tag.version.major}.${describe.tag.version.minor}.${describe.tag.version.patch.next}-SNAPSHOT</version>
+    </ref>
+    <ref type="tag">
+      <pattern><![CDATA[v(?<version>.*)]]></pattern>
+      <version>${ref.version}</version>
+    </ref>
+  </refs>
+
+  <rev>
+    <version>${commit}</version>
+  </rev>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>at.yawk.lz4</groupId>
   <artifactId>lz4-java</artifactId>
-  <version>0.0.0</version> <!-- set by jgitver-maven-plugin -->
+  <version>0.0.0</version> <!-- set by maven-git-versioning-extension -->
   <packaging>jar</packaging>
 
   <name>LZ4 Java Compression</name>


### PR DESCRIPTION
This extension is maintained and allows us to do proper SNAPSHOT builds.