### PR TITLE
Improve publish workflow

### DIFF
--- a/.github/workflows/build-all-and-publish.yml
+++ b/.github/workflows/build-all-and-publish.yml
@@ -209,7 +209,7 @@ jobs:
           java-version: '7'
 
       # with central credentials
-      - name: Setup Temurin JDK 21
+      - name: Setup Temurin JDK 21 (publish)
         uses: actions/setup-java@v5
         if: github.event_name == 'release' || inputs.publish
         with:
@@ -265,8 +265,8 @@ jobs:
               fi
             fi
           done
-          echo "Contents of target/classes/net:"
-          find target/classes/net -maxdepth 3 -type f -print
+          echo "Contents of target/classes/net/jpountz/util:"
+          find target/classes/net/jpountz/util -type f -print
 
       # with maven central
       - name: Build and deploy with Maven


### PR DESCRIPTION
- Give "Setup Temurin JDK" steps different names to tell them apart
- Fix native binary file names not being printed because they are too deeply nested
  See for example https://github.com/yawkat/lz4-java/actions/runs/19961510589/job/57243195307#step:7:36 where it did not show any file names.
  
   With this change it now properly prints the file names ([actions log](https://github.com/Marcono1234/lz4-java/actions/runs/19971057489/job/57276181623#step:7:36)):
   ```
   Contents of target/classes/net/jpountz/util:
   target/classes/net/jpountz/util/darwin/x86_64/liblz4-java.dylib
   target/classes/net/jpountz/util/darwin/aarch64/liblz4-java.dylib
   target/classes/net/jpountz/util/win32/amd64/liblz4-java.so
   target/classes/net/jpountz/util/linux/ppc64le/liblz4-java.so
   target/classes/net/jpountz/util/linux/s390x/liblz4-java.so
   target/classes/net/jpountz/util/linux/aarch64/liblz4-java.so
   target/classes/net/jpountz/util/linux/amd64/liblz4-java.so
   target/classes/net/jpountz/util/linux/i386/liblz4-java.so
   ```
