### PR TITLE
Migrate to macOS 15 x86_64 for release build

### DIFF
--- a/.github/workflows/build-all-and-publish.yml
+++ b/.github/workflows/build-all-and-publish.yml
@@ -97,11 +97,11 @@ jobs:
         include:
           - os: macos-15-intel
             arch: x86_64
-            java7: true
+            fullbuild: true
           - os: macos-14
             arch: aarch64
-            # Only build the native binary for this architecture; it suffices if only one of the macOS builds performs a full Maven build
-            java7: false
+            # Build only the native binary for this architecture; it suffices if only one of the macOS builds performs a full Maven build
+            fullbuild: false
 
     steps:
       - name: Checkout
@@ -112,7 +112,7 @@ jobs:
 
       - name: Setup Zulu JDK 7
         uses: actions/setup-java@v5
-        if: ${{ matrix.java7 }}
+        if: ${{ matrix.fullbuild }}
         with:
           distribution: zulu
           java-version: '7'
@@ -124,7 +124,7 @@ jobs:
           cache: maven
 
       - name: Build (native binary build only)
-        if: ${{ !matrix.java7 }}
+        if: ${{ !matrix.fullbuild }}
         run: |
           ./mvnw -B -V -DskipTests \
             -Darch.id=${{ matrix.arch }} \
@@ -132,7 +132,7 @@ jobs:
             process-resources
 
       - name: Build (full build)
-        if: ${{ matrix.java7 }}
+        if: ${{ matrix.fullbuild }}
         run: |
           ./mvnw -B -V \
             -Darch.id=${{ matrix.arch }} \


### PR DESCRIPTION
Because macOS 13 image is deprecated, see https://redirect.github.com/actions/runner-images/issues/13046

Also adjusts the build setup a bit to make it easier to understand.

> [!WARNING]
> I don't have a machine for testing this macOS binary locally. However, the full build on GitHub Actions [was successful on my fork](https://github.com/Marcono1234/lz4-java/actions/runs/19990333206/job/57330115680), so I hope that indicates that it works?
> Not sure though if there could be problems when users try to use this native binary on macOS 13 or 14.