### PR TITLE
Use gcc included in Windows image for release build

### DIFF
--- a/.github/workflows/build-all-and-publish.yml
+++ b/.github/workflows/build-all-and-publish.yml
@@ -168,6 +168,20 @@ jobs:
           java-version: '21'
           cache: maven
 
+      # See LZ4FrameIOStreamTest
+      - name: Download LZ4 CLI for tests
+        shell: powershell
+        run: |
+          curl.exe --fail-with-body --no-progress-meter --output lz4_win64.zip --location https://github.com/lz4/lz4/releases/download/v1.10.0/lz4_win64_v1_10_0.zip
+          mkdir lz4-cli
+          tar -x -v -f lz4_win64.zip -C lz4-cli lz4.exe
+          echo "$(Get-Location)\lz4-cli" >> "$env:GITHUB_PATH"
+          rm lz4_win64.zip
+      # Separate step because the change to PATH (through GITHUB_PATH) is not visible in the step which modified it
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#adding-a-system-path
+      - name: Check LZ4 CLI
+        run: lz4 -V
+
       - name: Build (mvn verify)
         shell: bash
         run: |


### PR DESCRIPTION
See https://github.com/actions/runner-images/blob/win25/20251125.122/images/windows/Windows2025-Readme.md#tools

This simplifies the build config a bit and probably also speeds it up.

Reproducibility-wise I am not sure if it makes a difference (or is actually an improvement) since the previous setup used `update: true` for the MSYS2 action, so could have broken reproducibility if a new gcc package was released in the meantime.
Using `gcc` from the GitHub runner image now at least preserves reproducibility until GitHub changes their runner image I guess.

~~Side note: The previous MSYS2 setup also installed the `mingw-w64-x86_64-lz4` package. I think that was redundant since this build is supposed to create the LZ4 binary from source, not use a prebuilt one in any way (?).~~