### PR TITLE
Rename windows JNI lib to liblz4-java.dll

### DIFF
--- a/.github/workflows/build-all-and-publish.yml
+++ b/.github/workflows/build-all-and-publish.yml
@@ -147,7 +147,7 @@ jobs:
           if-no-files-found: error
 
   windows:
-    name: Windows natives (win32/amd64)
+    name: Windows natives (windows/amd64)
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -188,8 +188,8 @@ jobs:
       - name: Upload native library
         uses: actions/upload-artifact@v4
         with:
-          name: natives-win32-amd64
-          path: target/classes/net/jpountz/util/win32/amd64/liblz4-java.so
+          name: natives-windows-amd64
+          path: target/classes/net/jpountz/util/windows/amd64/liblz4-java.dll
           if-no-files-found: error
 
   assemble:
@@ -244,13 +244,13 @@ jobs:
           shopt -s nullglob
           for dir in assemble/natives/*; do
             base="$(basename "$dir")"
-            # Expect names like natives-linux-amd64, natives-darwin-aarch64, natives-win32-amd64
+            # Expect names like natives-linux-amd64, natives-darwin-aarch64, natives-windows-amd64
             os="${base#natives-}"
             arch="${os#*-}"; os="${os%%-*}"
             case "$os" in
               linux) ext=so ;;
               darwin) ext=dylib ;;
-              win32) ext=so ;;
+              windows) ext=dll ;;
               *) echo "Unknown OS in artifact: $base" >&2; continue ;;
             esac
             dest="target/classes/net/jpountz/util/$os/$arch"

--- a/pom.xml
+++ b/pom.xml
@@ -539,9 +539,8 @@
                 <phase>process-resources</phase>
                 <configuration>
                   <target>
-                    <property name="os.id" value="win32"/>
-                    <!-- Keep .so to match current Native.resourceName() -->
-                    <property name="lib.ext" value="so"/>
+                    <property name="os.id" value="windows"/>
+                    <property name="lib.ext" value="dll"/>
 
                     <!-- Arch mapping (overridable via -Darch.id) -->
                     <property name="arch.id" value="${os.arch}"/>

--- a/src/java/net/jpountz/util/Native.java
+++ b/src/java/net/jpountz/util/Native.java
@@ -27,8 +27,7 @@ public enum Native {
   ;
 
   private enum OS {
-    // Even on Windows, the default compiler from cpptasks (gcc) uses .so as a shared lib extension
-    WINDOWS("win32", "so"), LINUX("linux", "so"), MAC("darwin", "dylib"), SOLARIS("solaris", "so");
+    WINDOWS("windows", "dll"), LINUX("linux", "so"), MAC("darwin", "dylib"), SOLARIS("solaris", "so");
     public final String name, libExtension;
 
     private OS(String name, String libExtension) {


### PR DESCRIPTION
This PR is renameing `net/jpountz/util/win32/amd64/liblz4-java.so` to `net/jpountz/util/windows/amd64/liblz4-java.dll`.

Tested on my local windows 11 machine.
<img width="1920" height="462" alt="image" src="https://github.com/user-attachments/assets/fcafcfc4-9c06-49ef-8325-fb0f95a28c57" />

Also tested the jar in `Apache TsFile` project on Windows.
<img width="3802" height="2048" alt="image" src="https://github.com/user-attachments/assets/0dccd4db-147d-45ba-8da8-577e92650b67" />
