### PR TITLE
Updated jdk build version from 1.7 to 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,13 +183,13 @@
               <goal>compile</goal>
             </goals>
             <configuration>
-              <source>1.7</source>
-              <target>1.7</target>
+              <source>21</source>
+              <target>21</target>
               <encoding>${project.build.sourceEncoding}</encoding>
               <debug>true</debug>
               <fork>true</fork>
               <jdkToolchain>
-                <version>7</version>
+                <version>21</version>
               </jdkToolchain>
             </configuration>
           </execution>


### PR DESCRIPTION
I have tried building v1.10.2 on my local machine but it was giving build error due to jdk version 1.7 mentioned in pom.xml. Updating that to 21 solves the error. The expected jdk version is 8 or above.