### PR TITLE
Fix docs production deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,20 +35,30 @@ jobs:
       - name: Build documentation
         if: github.event_name != 'workflow_dispatch' || !inputs.selected_version
         run: cd docs && just all
-      - name: Publish
+      - name: Publish production
+        if: github.event_name == 'release'
         uses: cloudflare/wrangler-action@v3
-        id: cf_publish
+        id: cf_publish_production
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy docs/target/site/ --project-name=lz4-java-yawk-at --branch=main
+      - name: Publish preview
+        if: github.event_name != 'release'
+        uses: cloudflare/wrangler-action@v3
+        id: cf_publish_preview
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy docs/target/site/ --project-name=lz4-java-yawk-at
       - name: Check PR
+        if: github.event_name != 'release'
         uses: 8BitJonny/gh-get-current-pr@3.0.0
         id: pr
       - name: Comment on PR
         if: steps.pr.outputs.pr_found
         uses: thollander/actions-comment-pull-request@v3
         with:
-          message: ":rocket: Preview deployed to ${{steps.cf_publish.outputs.deployment-url}}"
+          message: ":rocket: Preview deployed to ${{steps.cf_publish_preview.outputs.deployment-url}}"
           comment-tag: deployment
           pr-number: "${{steps.pr.outputs.number}}"


### PR DESCRIPTION
## Summary
Ensure the docs workflow publishes release builds to the Cloudflare Pages production branch instead of always creating preview deployments.

## Changes
- split docs publishing into separate production and preview steps
- deploy release builds with `--branch=main`
- keep PR preview comments tied to preview deployments only

## Why
Recent docs runs were creating preview deployments with source `HEAD`, while the production deployment remained stuck on an older `main` build.

Resolves #48