### PR TITLE
Fix docs code block line breaks

### DIFF
--- a/docs/justfile
+++ b/docs/justfile
@@ -34,7 +34,7 @@ template NAME TAG: (repo TAG)
 
   selected_version_actual = '{{TAG}}' if '{{TAG}}' != '{{latest_version_name}}' else '{{latest_version}}'
 
-  html_formatter = pygments.formatters.HtmlFormatter(lineseparator="<br>")
+  html_formatter = pygments.formatters.HtmlFormatter()
   class PygmentsRenderer(mistune.HTMLRenderer):
     def block_code(self, code, info=None):
       if info:


### PR DESCRIPTION
## Summary
- remove the custom Pygments line separator from the docs generator
- restore normal newline rendering for highlighted README code blocks
- stop published documentation from showing literal `<br>` tags in code snippets

## Verification
- confirmed the published site symptom matches the old `HtmlFormatter(lineseparator="<br>")` configuration
- updated `docs/justfile` to use the default formatter newline handling
- verified the local diff is limited to the docs generation pipeline

Resolves #51