### PR TITLE
Update workflows to Java 25

### DIFF
--- a/.github/workflows/build-all-and-publish.yml
+++ b/.github/workflows/build-all-and-publish.yml
@@ -66,11 +66,11 @@ jobs:
         with:
           distribution: zulu
           java-version: '7'
-      - name: Setup Temurin JDK 21
+      - name: Setup Temurin JDK 25
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: '25'
           cache: maven
 
       - name: Install cross toolchain (if needed)
@@ -124,11 +124,11 @@ jobs:
         with:
           distribution: zulu
           java-version: '7'
-      - name: Setup Temurin JDK 21
+      - name: Setup Temurin JDK 25
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: '25'
           cache: maven
 
       - name: Build (native binary build only)
@@ -169,11 +169,11 @@ jobs:
         with:
           distribution: zulu
           java-version: '7'
-      - name: Setup Temurin JDK 21
+      - name: Setup Temurin JDK 25
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: '25'
           cache: maven
 
       # See LZ4FrameIOStreamTest
@@ -223,12 +223,12 @@ jobs:
           java-version: '7'
 
       # with central credentials
-      - name: Setup Temurin JDK 21 (publish)
+      - name: Setup Temurin JDK 25 (publish)
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         if: github.event_name == 'release' || inputs.publish
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: '25'
           cache: maven
           gpg-private-key: ${{ secrets.GPG_KEY }}
           gpg-passphrase: GPG_PASSWORD
@@ -236,12 +236,12 @@ jobs:
           server-username: CENTRAL_TOKEN_USERNAME
           server-password: CENTRAL_TOKEN_PASSWORD
       # without central credentials
-      - name: Setup Temurin JDK 21
+      - name: Setup Temurin JDK 25
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         if: github.event_name != 'release' && !inputs.publish
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: '25'
           cache: maven
 
       - name: Download natives

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,11 +19,11 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-      - name: Setup Temurin JDK 21
+      - name: Setup Temurin JDK 25
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: '25'
           cache: maven
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,11 +36,11 @@ jobs:
         with:
           distribution: zulu
           java-version: '7'
-      - name: Setup Temurin JDK 21
+      - name: Setup Temurin JDK 25
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: '25'
           cache: maven
       - name: Build (mvn verify)
         run: |


### PR DESCRIPTION
## Summary

- run tests and documentation builds on Temurin JDK 25
- run native packaging and publishing jobs on Temurin JDK 25
- preserve the Java 7 compilation toolchain and Java 21 test bytecode target

## Verification

- parsed all workflow YAML files successfully
- verified all seven workflow runtime pins use JDK 25
- ran `./mvnw verify` on OpenJDK 25.0.4: 1,742 tests, 0 failures/errors, 34 skipped

Resolves #81