### PR TITLE
Restore Javadoc output directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -310,6 +310,7 @@
           </execution>
         </executions>
         <configuration>
+          <outputDirectory>${project.build.directory}/site</outputDirectory>
           <release>25</release>
           <excludePackageNames>net.jpountz.util</excludePackageNames>
         </configuration>


### PR DESCRIPTION
## Summary

- configure Maven Javadoc output under `target/site`
- restore the `target/site/apidocs` path expected by the documentation build

The Maven Javadoc Plugin 3.12.0 defaults direct report output to `target/reports`, while the documentation recipe still consumes `target/site/apidocs`.

## Verification

- `./mvnw -ntp javadoc:javadoc`
- verified `target/site/apidocs/index.html` is generated
- `./mvnw -B -ntp -V -Dtest='!net/jpountz/fuzz/*' -Dmaven.compiler.source=8 -Dmaven.compiler.target=8 -Dnative.cc=gcc -Dsurefire.reportFormat=plain clean verify` (1,680 tests passed)

Resolves #94